### PR TITLE
validating search screen input text

### DIFF
--- a/AndroidApp/app/src/main/java/paniuta/trackmywords/ResultScreen.java
+++ b/AndroidApp/app/src/main/java/paniuta/trackmywords/ResultScreen.java
@@ -79,7 +79,7 @@ public class ResultScreen extends ActionBarActivity implements View.OnClickListe
                 message = textSongSelected.getText().toString();
                 break;
             case R.id.tv2:
-                textSongSelected = (TextView) findViewById(R.id.tv1);
+                textSongSelected = (TextView) findViewById(R.id.tv2);
                 message = textSongSelected.getText().toString();
                 break;
             case R.id.tv3:

--- a/AndroidApp/app/src/main/java/paniuta/trackmywords/SearchScreen.java
+++ b/AndroidApp/app/src/main/java/paniuta/trackmywords/SearchScreen.java
@@ -57,10 +57,18 @@ public class SearchScreen extends ActionBarActivity {
         EditText textToSearch = (EditText) findViewById(R.id.tfTypeLyrics);
         String message = textToSearch.getText().toString();
 
-        // putExtra adds the text value to the intent in key-value pairs
-        intent.putExtra(EXTRA_MESSAGE, message);
-        startActivity(intent);
-        // system receives call and starts an instance of the Activity specified by the Intent object
+        //check if input is not blank and at least 3 characters
+        if( message.length() < 3 )
+            textToSearch.setError( "Too short!" );
+
+        else {
+            // putExtra adds the text value to the intent in key-value pairs
+            intent.putExtra(EXTRA_MESSAGE, message);
+            startActivity(intent);
+            // system receives call and starts an instance of the Activity specified by the Intent object
+        }
+
+
     }
 
 }

--- a/AndroidApp/app/src/main/res/layout/activity_search_screen.xml
+++ b/AndroidApp/app/src/main/res/layout/activity_search_screen.xml
@@ -18,6 +18,10 @@
     <EditText
         android:layout_width="500px"
         android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:lines="1"
+        android:maxLines="1"
+        android:scrollHorizontally="true"
         android:id="@+id/tfTypeLyrics"
         android:layout_below="@+id/txtTitle"
         android:layout_centerHorizontal="true"

--- a/AndroidApp/app/src/main/res/layout/activity_search_screen.xml
+++ b/AndroidApp/app/src/main/res/layout/activity_search_screen.xml
@@ -22,7 +22,7 @@
         android:layout_below="@+id/txtTitle"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="60dp"
-        android:text="Type lyrics..." />
+        android:hint="Type lyrics..." />
 
     <Button
         android:layout_width="wrap_content"


### PR DESCRIPTION
- before sending to db
- search text cannot be blank
- at least 3 characters in length
- error prompt when ’Search’ button is clicked: “Too short!”
- fixed minor typo on ResultScreen
